### PR TITLE
Prettier fix

### DIFF
--- a/.github/workflows/lint-check.yaml
+++ b/.github/workflows/lint-check.yaml
@@ -9,6 +9,12 @@ jobs:
         with:
           node-version: '18'
       - run: npm install next
+      - name: Debug Info
+        run: |
+          echo "Node Version: $(node --version)"
+          echo "Prettier Version: $(npx prettier --version)"
+          echo "Prettier Config: $(cat .prettierrc)"
+          echo "GitHub Actions Environment: ${{ toJson(env) }}"
       - run: npm run lint:check
       - run: npm run format
       - run: cat tsconfig.json

--- a/.github/workflows/lint-check.yaml
+++ b/.github/workflows/lint-check.yaml
@@ -11,3 +11,7 @@ jobs:
       - run: npm install next
       - run: npm run lint:check
       - run: npm run format:check
+      - run: npm run format
+      - run: cat tsconfig.json
+      - run: git diff tsconfig.json
+      - run: npm run format:check

--- a/.github/workflows/lint-check.yaml
+++ b/.github/workflows/lint-check.yaml
@@ -9,14 +9,5 @@ jobs:
         with:
           node-version: '18'
       - run: npm install next
-      - name: Debug Info
-        run: |
-          echo "Node Version: $(node --version)"
-          echo "Prettier Version: $(npx prettier --version)"
-          echo "Prettier Config: $(cat .prettierrc)"
-          echo "GitHub Actions Environment: ${{ toJson(env) }}"
       - run: npm run lint:check
-      - run: npm run format
-      - run: cat tsconfig.json
-      - run: git diff tsconfig.json
       - run: npm run format:check

--- a/.github/workflows/lint-check.yaml
+++ b/.github/workflows/lint-check.yaml
@@ -10,7 +10,6 @@ jobs:
           node-version: '18'
       - run: npm install next
       - run: npm run lint:check
-      - run: npm run format:check
       - run: npm run format
       - run: cat tsconfig.json
       - run: git diff tsconfig.json

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint": "^8.48.0",
     "eslint-config-next": "^13.4.19",
     "postcss": "^8.4.29",
-    "prettier": "^3.0.3",
+    "prettier": "^3.2.4",
     "tailwindcss": "^3.3.3",
     "typescript": "5.2.2"
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint:check": "next lint",
     "lint": "next lint --fix",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check . --log-level debug"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.17",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint:check": "next lint",
     "lint": "next lint --fix",
-    "format": "prettier --write .",
+    "format": "prettier --write . --log-level debug",
     "format:check": "prettier --check . --log-level debug"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "start": "next start",
     "lint:check": "next lint",
     "lint": "next lint --fix",
-    "format": "prettier --write . --log-level debug",
-    "format:check": "prettier --check . --log-level debug"
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@headlessui/react": "^1.7.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ devDependencies:
     specifier: ^8.4.29
     version: 8.4.29
   prettier:
-    specifier: ^3.0.3
-    version: 3.0.3
+    specifier: ^3.2.4
+    version: 3.2.4
   tailwindcss:
     specifier: ^3.3.3
     version: 3.3.3
@@ -4186,8 +4186,8 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier@3.0.3:
-    resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
+  /prettier@3.2.4:
+    resolution: {integrity: sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,9 +15,9 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@/*": ["./src/*"]
-    }
+      "@/*": ["./src/*"],
+    },
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
 }


### PR DESCRIPTION
`tsconfig.json` was failing prettier lint check. This is because a newer version of prettier was parsing `tsconfig.json` as jsonc not json, which is acceptable, and adding trailing commas. This bumps prettier to that version for consistency and adds those trailing commas.