### PR TITLE
Fix governance period switching

### DIFF
--- a/src/components/Governance.tsx
+++ b/src/components/Governance.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import PeriodLinks from '@/components/PeriodLinks';
@@ -13,6 +13,9 @@ const fallbackSrc = '/governance/blank.jpg';
 
 const LeadershipCard = (props: Person) => {
   const [src, setSrc] = useState(`/governance/${props.netId}.jpg`);
+  useEffect(() => {
+    setSrc(`/governance/${props.netId}.jpg`);
+  }, [props.netId]);
   return (
     <div className="p-2 flex flex-col items-center grow-0 w-72 gap-4">
       <Image

--- a/src/components/PeriodLinks.tsx
+++ b/src/components/PeriodLinks.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { Listbox, Transition } from '@headlessui/react';
+import { Listbox, ListboxButton, ListboxOption, Transition } from '@headlessui/react';
 
 interface PeriodLinkProps {
   name: string;
@@ -22,14 +22,14 @@ const PeriodLinks = (props: PeriodLinkProps) => {
         <Listbox>
           {({ open }) => (
             <>
-              <Listbox.Button
+              <ListboxButton
                 className={
                   'transition-all duration-300 ease-in-out px-2 py-1 cursor-pointer border-x-2 border-t-2 hover:bg-royal hover:text-white border-royal rounded-t-lg' +
                   (open ? '' : ' rounded-b-lg border-2')
                 }
               >
                 {props.name}
-              </Listbox.Button>
+              </ListboxButton>
               <Transition
                 as="div"
                 className="transition-all duration-500 overflow-hidden"
@@ -40,7 +40,7 @@ const PeriodLinks = (props: PeriodLinkProps) => {
               >
                 <div className="rounded-b-lg border-2 border-royal max-h-48 overflow-auto">
                   {periods.map((period, index) => (
-                    <Listbox.Option
+                    <ListboxOption
                       key={period}
                       value={period}
                       className={
@@ -53,7 +53,7 @@ const PeriodLinks = (props: PeriodLinkProps) => {
                       >
                         <h3 className="text-xl font-semibold">{period}</h3>
                       </Link>
-                    </Listbox.Option>
+                    </ListboxOption>
                   ))}
                 </div>
               </Transition>

--- a/src/components/PeriodLinks.tsx
+++ b/src/components/PeriodLinks.tsx
@@ -47,12 +47,12 @@ const PeriodLinks = (props: PeriodLinkProps) => {
                         'p-2' + (index === periods.length - 1 ? '' : ' border-b-2 border-royal')
                       }
                     >
-                      <Link
+                      <a
                         className="underline decoration-transparent hover:decoration-inherit transition"
                         href={urls[index]}
                       >
                         <h3 className="text-xl font-semibold">{period}</h3>
-                      </Link>
+                      </a>
                     </Listbox.Option>
                   ))}
                 </Listbox.Options>

--- a/src/components/PeriodLinks.tsx
+++ b/src/components/PeriodLinks.tsx
@@ -38,7 +38,7 @@ const PeriodLinks = (props: PeriodLinkProps) => {
                 leaveFrom="transform opacity-100 max-h-48"
                 leaveTo="transform max-h-0"
               >
-                <Listbox.Options className="rounded-b-lg border-2 border-royal max-h-48 overflow-auto">
+                <div className="rounded-b-lg border-2 border-royal max-h-48 overflow-auto">
                   {periods.map((period, index) => (
                     <Listbox.Option
                       key={period}
@@ -47,15 +47,15 @@ const PeriodLinks = (props: PeriodLinkProps) => {
                         'p-2' + (index === periods.length - 1 ? '' : ' border-b-2 border-royal')
                       }
                     >
-                      <a
+                      <Link
                         className="underline decoration-transparent hover:decoration-inherit transition"
                         href={urls[index]}
                       >
                         <h3 className="text-xl font-semibold">{period}</h3>
-                      </a>
+                      </Link>
                     </Listbox.Option>
                   ))}
-                </Listbox.Options>
+                </div>
               </Transition>
             </>
           )}


### PR DESCRIPTION
It is a synchronization issue. Initially, in Governance.tsx, `const [src, setSrc] = useState(`/governance/${props.netId}.jpg`);` is set for the LeadershipCard. When `props.netId` changes, though, src is not updated (useState doesn't automatically handle this). So we need to call `setSrc(props.netId)` somehow whenever the props changes.

Enter a useEffect. I set the trigger to `props.netId` so whenever the period changes, props change, and the image changes as well
_There was no error when changing from "Current" to an older period because about/governance/index.tsx (current) and about/governance/[period].tsx are seperate files. In [period].tsx I think the Governance component is reused with new props passed._

---
For the page freeze, I suspect it has to do with Listbox.Option wrapping the actual options. I changed it to a div instead and it works and looks the same.

---