### PR TITLE
feat: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS for UTDNebula/website-v2
+# GitHub will automatically request reviews from the owners below
+# when a pull request modifies the matching files.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global owners — own everything unless a more specific rule below overrides
+* @TyHil @NishilJ


### PR DESCRIPTION
## Description
Adds `.github/CODEOWNERS` to assign automatic code review requests to the project leads.

Closes #140

## Related
- UTDNebula/skedge#114
- UTDNebula/utd-rooms#124

## Changes
- Created `.github/CODEOWNERS` with a global `*` rule assigning `@TyHil` and `@NishilJ` as owners